### PR TITLE
Fix DCLoad

### DIFF
--- a/make-cd/Makefile
+++ b/make-cd/Makefile
@@ -1,6 +1,5 @@
 CDRECORD	= wodim dev=0,0,0 speed=8
 #CDRECORD	= wodim dev=ATAPI:0,0,0 speed=8
-SCRAMBLE	= scramble
 DD		= dd
 CP		= cp
 MKISOFS		= genisoimage
@@ -21,7 +20,6 @@ burn-audio: audio.raw
 	touch burn-audio
 
 1st_read.bin: $(1ST_READ)
-	$(SCRAMBLE) $(1ST_READ) 1st_read.bin
 	cp $(1ST_READ) 1st_read.bin
 
 data.raw: tmp.iso IP.BIN

--- a/target-src/1st_read/Makefile
+++ b/target-src/1st_read/Makefile
@@ -19,5 +19,9 @@ loader.elf: loader.s disable.s ../dcload/dcload.bin ../dcload/exception.bin
 	$(TARGETCC) $(TARGETCFLAGS) -o $@ loader.s disable.s -nostartfiles \
 	    -nostdlib -Ttext=0x8c010000 -Wa,-I../dcload
 
-1st_read.bin: loader.elf
-	$(TARGETOBJCOPY) -R .stack -O binary $^ $@
+loader.bin: loader.elf
+	$(TARGETOBJCOPY) -O binary $^ $@
+
+# 1st_read.bin
+$(TARGET): loader.bin
+	$(KOS_BASE)/utils/scramble/scramble $< $@


### PR DESCRIPTION
Remove -R .stack from dcload compiling.

1st_read.bin is typically seen as a file that is already scrambled.  So I moved the scrambling to the creation of 1st_read.bin and removed it from make-cd Makefile.  This change was in Sizious repo but forgot to include it.  That is why scrambled was removed that one time. 