### PR TITLE
dc-tool: BFD: Automatically link with SFrame if needed

### DIFF
--- a/host-src/tool/Makefile
+++ b/host-src/tool/Makefile
@@ -8,8 +8,14 @@ LDFLAGS = $(HOSTLDFLAGS)
 INCLUDE	= -I$(LZOPATH) -I/usr/local/include
 
 ifeq ($(WITH_BFD),1)
+  # Starting from Binutils 2.40, SFrame is required when using BFD
+  LIBSFRAME	=
+  ifneq ("$(wildcard $(TARGETPREFIX)/lib/libsframe.a)","")
+    LIBSFRAME = -lsframe
+  endif
+  
   CFLAGS	+= -DWITH_BFD
-  LDFLAGS	= -L$(BFDLIB) -lbfd -liberty -lintl -lz
+  LDFLAGS	= -L$(BFDLIB) -lbfd $(LIBSFRAME) -liberty -lintl -lz
   INCLUDE	+= -I$(BFDINCLUDE)
 else
   LDFLAGS	= -L$(ELFLIB) -lelf


### PR DESCRIPTION
Starting from **Binutils 2.40**, SFrame is required when using BFD for building `dc-tool-ser`. [More details here]( https://www.phoronix.com/news/GNU-Binutils-SFrame).

The `libsframe` library is installed by `dc-chain` in a predefined location so this little PR will add `-lsframe` to the `dc-tool-ser`'s build command line if the library is found in the correct location, typically `/opt/toolchains/dc/sh-elf/lib`. Basically, BFD (and SFrame) will be automatically installed if the `sh-elf` toolchain is built on MinGW/MSYS environment or if the `sh_force_libbfd_installation` flag is set to `1` in `config.mk` (see `dc-chain` documentation).