### PR TITLE
`dc-tool`: Improvements for maximizing compatibility

### DIFF
--- a/Makefile.cfg
+++ b/Makefile.cfg
@@ -77,7 +77,7 @@ VERSION = 1.0.6
 
 # This is on by default for Windows (MinGW/MSYS, MinGW-w64/MSYS2 and Cygwin)
 ifdef WINDOWS
-  STANDALONE_BINARY = 1  
+  STANDALONE_BINARY = 1
 endif
 
 # this is the default port for dc-tool, it can be changed on the commandline

--- a/Makefile.cfg
+++ b/Makefile.cfg
@@ -34,10 +34,10 @@ ifdef MINGW
   WITH_BFD = 1
 endif
 
-# You may have to change the paths for BFDLIB and BFDINCLUDE to the correct 
-# ones for your system. These must point to your sh-elf bfd, not the system one!
-# If you built the dc-chain with the v0.4, you'll have it installed in the
-# correct location.
+# You may have to change the paths for BFDLIB and BFDINCLUDE to the correct
+# ones for your system. These must point to your sh-elf BFD, not the system one!
+# If you built your Sega Dreamcast toolchains with dc-chain, you'll have it
+# installed in the correct location.
 BFDLIB			= $(TARGETPREFIX)/lib
 BFDINCLUDE		= $(TARGETPREFIX)/include
 
@@ -60,7 +60,7 @@ TARGETLD		= $(TARGETPREFIX)/bin/sh-elf-ld
 
 # set TARGETCCVER to 3 or 4, depending on your SH compiler version (gcc 3.x or gcc 4.x)
 # this line tries to detect the version automatically
-
+# This only matters for building the example sources.
 # if version > 4 then it's 4
 TARGETCCVER		= $(shell $(TARGETCC) --version | head -1 | sed  "s/.* \([[:digit:]][[:digit:]]*\)\.[[:digit:]][[:digit:]]*.*/\1/")
 ifeq ($(shell test $(TARGETCCVER) -gt 4; echo $$?),0)
@@ -69,7 +69,8 @@ endif
 
 # You generally shouldn't change this unless you are making forked
 # versions (or test versions)
-VERSION			= 1.0.6
+# Version numbers must be of the form x.x.x
+VERSION = 1.0.6
 
 # Define this if you want a standalone, statically linked, no dependency binary
 #STANDALONE_BINARY = 1
@@ -88,7 +89,7 @@ SERIALDEVICE	= /dev/ttyS0
 # port each time.
 #SERIALDEVICE	= /dev/cu.usbserial-5B24
 
-# for Windows it's usually COM1
+# Windows -- it's usually COM1
 ifdef WINDOWS
   SERIALDEVICE = COM1
 endif

--- a/Makefile.cfg
+++ b/Makefile.cfg
@@ -12,7 +12,6 @@ HOSTLDFLAGS		= -L/usr/local/lib
 # For MinGW/MSYS, MinGW-w64/MSYS2 and Cygwin
 ifdef WINDOWS
   HOSTCFLAGS += -D_WIN32
-  HOSTLDFLAGS += -static
   EXECUTABLEEXTENSION = .exe
 endif
 
@@ -23,8 +22,9 @@ TARGETPREFIX	= /opt/toolchains/dc/sh-elf
 # dir to install dc-tool in
 TOOLINSTALLDIR	= /opt/toolchains/dc/bin
 
-# To build dc-tool, we need to use libelf or libfd
-# By default, libelf is used
+# To build dc-tool, we need to use libelf or libbfd
+# By default, libelf is used, except for MinGW/MSYS which uses libbfd.
+# libbfd is installed using dc-chain, an utility provided with KallistiOS.
 
 # Define this if you want to use libbfd instead of libelf (which is default)
 WITH_BFD = 0
@@ -72,10 +72,15 @@ endif
 VERSION			= 1.0.6
 
 # Define this if you want a standalone, statically linked, no dependency binary
-# This is on by default for MinGW/MSYS
 #STANDALONE_BINARY = 1
 
+# This is on by default for Windows (MinGW/MSYS, MinGW-w64/MSYS2 and Cygwin)
+ifdef WINDOWS
+  STANDALONE_BINARY = 1  
+endif
+
 # this is the default port for dc-tool, it can be changed on the commandline
+# used for *nix systems
 SERIALDEVICE	= /dev/ttyS0
 
 # macOS -- you'll need to go look in /dev to see what the actual device
@@ -83,6 +88,7 @@ SERIALDEVICE	= /dev/ttyS0
 # port each time.
 #SERIALDEVICE	= /dev/cu.usbserial-5B24
 
+# for Windows it's usually COM1
 ifdef WINDOWS
   SERIALDEVICE = COM1
 endif

--- a/host-src/tool/Makefile
+++ b/host-src/tool/Makefile
@@ -14,7 +14,7 @@ endif
 
 # Determine if we need zlib or not in that context for building dc-tool
 # The purpose of that is just to have '-lz' once at the end of the command line
-ZLIB_REQUIRED = 0
+ZLIB_REQUIRED := 0
 
 # Linking with 'libelf' or 'libbfd' (sh-elf), depending of 'Makefile.cfg'
 ifeq ($(WITH_BFD),1)
@@ -23,12 +23,12 @@ ifeq ($(WITH_BFD),1)
   ifneq ("$(wildcard $(TARGETPREFIX)/lib/libsframe.a)","")
     LIBSFRAME = -lsframe
   endif
-    
+  
   CFLAGS	+= -DWITH_BFD
   LDFLAGS	+= -L$(BFDLIB) -lbfd $(LIBSFRAME) -liberty -lintl
   INCLUDE	+= -I$(BFDINCLUDE)
   
-  ZLIB_REQUIRED = 1  
+  ZLIB_REQUIRED := 1
 else
   LDFLAGS	+= -L$(ELFLIB) -lelf
   INCLUDE	+= -I$(ELFINCLUDE)
@@ -37,7 +37,7 @@ endif
 # Additional libraries for MinGW/MSYS or MinGW-w64/MSYS2
 ifdef MINGW32
   LDFLAGS	+= -lws2_32 -lwsock32 -liconv
-  ZLIB_REQUIRED = 1  
+  ZLIB_REQUIRED := 1
 endif
 
 # Add zlib to the command line end... if required

--- a/host-src/tool/Makefile
+++ b/host-src/tool/Makefile
@@ -47,7 +47,7 @@ endif
 
 DCTOOL	= dc-tool-ser$(EXECUTABLEEXTENSION)
 
-OBJECTS	= dc-tool.o minilzo.o syscalls.o unlink.o
+OBJECTS	= dc-tool.o minilzo.o syscalls.o unlink.o utils.o
 LZOFILES = $(LZOPATH)/minilzo.c $(LZOPATH)/minilzo.h $(LZOPATH)/lzoconf.h
 
 .c.o:

--- a/host-src/tool/Makefile
+++ b/host-src/tool/Makefile
@@ -5,7 +5,7 @@ LZOPATH = ../../minilzo.106
 CC		= $(HOSTCC)
 CFLAGS	= $(HOSTCFLAGS) -DDCLOAD_VERSION=\"$(VERSION)\" -DBAUD_RATE=$(SERIALSPEED) -DSERIALDEVICE="\"$(SERIALDEVICE)\"" -DHAVE_GETOPT -DB1500000 -DB500000
 LDFLAGS = $(HOSTLDFLAGS)
-INCLUDE	= -I$(LZOPATH) -I/usr/local/include
+INCLUDE = -I$(LZOPATH) -I/usr/local/include
 
 # Adding static flag if asked
 ifeq ($(STANDALONE_BINARY),1)
@@ -51,7 +51,7 @@ OBJECTS	= dc-tool.o minilzo.o syscalls.o unlink.o utils.o
 LZOFILES = $(LZOPATH)/minilzo.c $(LZOPATH)/minilzo.h $(LZOPATH)/lzoconf.h
 
 .c.o:
-	$(CC) $(CFLAGS) $(INCLUDE) -o $@ -c $< 
+	$(CC) $(CFLAGS) $(INCLUDE) -o $@ -c $<
 
 all: $(DCTOOL)
 
@@ -62,7 +62,7 @@ minilzo.o: $(LZOFILES)
 	$(CC) $(CFLAGS) $(INCLUDE) -o $@ -c $< 
 
 .PHONY : install
-install: $(DCTOOL) | $(TOOLINSTALLDIR)	
+install: $(DCTOOL) | $(TOOLINSTALLDIR)
 	cp $(DCTOOL) $(TOOLINSTALLDIR)
 $(TOOLINSTALLDIR):
 	-mkdir $(TOOLINSTALLDIR)
@@ -72,5 +72,5 @@ clean:
 	rm -f $(OBJECTS)
 
 .PHONY : distclean
-distclean: clean 
+distclean: clean
 	rm -f $(DCTOOL)

--- a/host-src/tool/Makefile
+++ b/host-src/tool/Makefile
@@ -7,30 +7,42 @@ CFLAGS	= $(HOSTCFLAGS) -DDCLOAD_VERSION=\"$(VERSION)\" -DBAUD_RATE=$(SERIALSPEED
 LDFLAGS = $(HOSTLDFLAGS)
 INCLUDE	= -I$(LZOPATH) -I/usr/local/include
 
-# Linking with libelf or libbfd, depending of Makefile.cfg
+# Determine if we need zlib or not in that context for building dc-tool
+# The purpose of that is just to have '-lz' once at the end of the command line
+ZLIB_REQUIRED = 0
+
+# Linking with 'libelf' or 'libbfd' (sh-elf), depending of 'Makefile.cfg'
 ifeq ($(WITH_BFD),1)
   # Starting from Binutils 2.40, SFrame is required when using BFD
   LIBSFRAME	=
   ifneq ("$(wildcard $(TARGETPREFIX)/lib/libsframe.a)","")
     LIBSFRAME = -lsframe
   endif
-  
+    
   CFLAGS	+= -DWITH_BFD
-  LDFLAGS	= -L$(BFDLIB) -lbfd $(LIBSFRAME) -liberty -lintl -lz
+  LDFLAGS	= -L$(BFDLIB) -lbfd $(LIBSFRAME) -liberty -lintl
   INCLUDE	+= -I$(BFDINCLUDE)
+  
+  ZLIB_REQUIRED = 1  
 else
   LDFLAGS	= -L$(ELFLIB) -lelf
   INCLUDE	+= -I$(ELFINCLUDE)
 endif
 
-# Additional libraries for MinGW/MSYS
+# Additional libraries for MinGW/MSYS or MinGW-w64/MSYS2
 ifdef MINGW32
   LDFLAGS	+= -lws2_32 -lwsock32 -liconv
+  ZLIB_REQUIRED = 1  
+endif
+
+# Add zlib to the command line end... if required
+ifeq ($(ZLIB_REQUIRED),1)
+  LDFLAGS	+= -lz
 endif
 
 # Adding static flag if asked
 ifeq ($(STANDALONE_BINARY),1)
-  LDFLAGS += -lz -static
+  LDFLAGS += -static
 endif
 
 DCTOOL	= dc-tool-ser$(EXECUTABLEEXTENSION)

--- a/host-src/tool/Makefile
+++ b/host-src/tool/Makefile
@@ -7,6 +7,11 @@ CFLAGS	= $(HOSTCFLAGS) -DDCLOAD_VERSION=\"$(VERSION)\" -DBAUD_RATE=$(SERIALSPEED
 LDFLAGS = $(HOSTLDFLAGS)
 INCLUDE	= -I$(LZOPATH) -I/usr/local/include
 
+# Adding static flag if asked
+ifeq ($(STANDALONE_BINARY),1)
+  LDFLAGS += -static
+endif
+
 # Determine if we need zlib or not in that context for building dc-tool
 # The purpose of that is just to have '-lz' once at the end of the command line
 ZLIB_REQUIRED = 0
@@ -20,12 +25,12 @@ ifeq ($(WITH_BFD),1)
   endif
     
   CFLAGS	+= -DWITH_BFD
-  LDFLAGS	= -L$(BFDLIB) -lbfd $(LIBSFRAME) -liberty -lintl
+  LDFLAGS	+= -L$(BFDLIB) -lbfd $(LIBSFRAME) -liberty -lintl
   INCLUDE	+= -I$(BFDINCLUDE)
   
   ZLIB_REQUIRED = 1  
 else
-  LDFLAGS	= -L$(ELFLIB) -lelf
+  LDFLAGS	+= -L$(ELFLIB) -lelf
   INCLUDE	+= -I$(ELFINCLUDE)
 endif
 
@@ -38,11 +43,6 @@ endif
 # Add zlib to the command line end... if required
 ifeq ($(ZLIB_REQUIRED),1)
   LDFLAGS	+= -lz
-endif
-
-# Adding static flag if asked
-ifeq ($(STANDALONE_BINARY),1)
-  LDFLAGS += -static
 endif
 
 DCTOOL	= dc-tool-ser$(EXECUTABLEEXTENSION)

--- a/host-src/tool/Makefile
+++ b/host-src/tool/Makefile
@@ -7,6 +7,7 @@ CFLAGS	= $(HOSTCFLAGS) -DDCLOAD_VERSION=\"$(VERSION)\" -DBAUD_RATE=$(SERIALSPEED
 LDFLAGS = $(HOSTLDFLAGS)
 INCLUDE	= -I$(LZOPATH) -I/usr/local/include
 
+# Linking with libelf or libbfd, depending of Makefile.cfg
 ifeq ($(WITH_BFD),1)
   # Starting from Binutils 2.40, SFrame is required when using BFD
   LIBSFRAME	=
@@ -27,8 +28,9 @@ ifdef MINGW32
   LDFLAGS	+= -lws2_32 -lwsock32 -liconv
 endif
 
-ifdef STANDALONE_BINARY
-	LDFLAGS += -lz -static
+# Adding static flag if asked
+ifeq ($(STANDALONE_BINARY),1)
+  LDFLAGS += -lz -static
 endif
 
 DCTOOL	= dc-tool-ser$(EXECUTABLEEXTENSION)

--- a/host-src/tool/utils.c
+++ b/host-src/tool/utils.c
@@ -1,0 +1,73 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdarg.h>
+
+/* Detect MinGW/MSYS vs. MinGW-w64/MSYS2 */
+#ifdef __MINGW32__
+#include <_mingw.h>
+# ifdef __MINGW64_VERSION_MAJOR
+#  define __RT_MINGW_W64__
+# else
+#  define __RT_MINGW_ORG__
+# endif
+#endif /* __MINGW32__ */
+
+#ifdef __RT_MINGW_ORG__
+
+/*
+ * Compatibility layer for original, legacy MinGW/MSYS environment.
+ * This allow toolchains built on MinGW-w64/MSYS2 to be usable with MinGW/MSYS.
+ * Mainly, this is for linking 'dc-tool' with 'libbfd'. Declaring these
+ * functions will let us to build 'dc-tool' even if 'sh-elf' toolchain was built
+ * on MinGW-w64/MSYS2.
+ */
+
+// Thanks to Dietrich Epp
+// See: https://stackoverflow.com/a/40160038
+int vasprintf(char **strp, const char *fmt, va_list ap) {    
+    int len = _vscprintf(fmt, ap);
+    if (len == -1) {
+        return -1;
+    }
+    size_t size = (size_t)len + 1;
+    char *str = malloc(size);
+    if (!str) {
+        return -1;
+    }    
+    int r = __mingw_vsnprintf(str, len + 1, fmt, ap);
+    if (r == -1) {
+        free(str);
+        return -1;
+    }
+    *strp = str;
+    return r;
+}
+
+// Thanks to Dietrich Epp
+// See: https://stackoverflow.com/a/40160038
+int __cdecl __MINGW_NOTHROW libintl_asprintf(char **strp, const char *fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    int r = vasprintf(strp, fmt, ap);
+    va_end(ap);
+    return r;
+}
+
+// See: https://stackoverflow.com/a/60380005
+int __cdecl __MINGW_NOTHROW __ms_vsnprintf(char *buffer, size_t count, const char *format, va_list argptr) {
+	return __mingw_vsnprintf(buffer, count, format, argptr);
+}
+
+// Thanks to Kenji Uno and god
+// See: https://github.com/HiraokaHyperTools/libacrt_iob_func
+// See: https://stackoverflow.com/a/30894349
+FILE * __cdecl __MINGW_NOTHROW _imp____acrt_iob_func(int handle) {
+    switch (handle) {
+        case 0: return stdin;
+        case 1: return stdout;
+        case 2: return stderr;
+    }
+    return NULL;
+}
+
+#endif /* __RT_MINGW_ORG__ */


### PR DESCRIPTION
This little PR is for maximizing the compatibility for `dc-tool`, mainly for MinGW/MSYS.
- Better handling of `zlib` linking (avoid to link the `zlib` library several times)
- `LDFLAGS` are taking into account initial values even after `libbfd` or `libelf` usage
- Support for MinGW-w64/MSYS2 toolchain on MinGW/MSYS (mainly for GCC 12 and DreamSDK)