### PR TITLE
Fix issue #10, dc-tool-ser does not work if compiled with BAUD_RATE != 57600

### DIFF
--- a/host-src/tool/dc-tool.c
+++ b/host-src/tool/dc-tool.c
@@ -1316,10 +1316,10 @@ int main(int argc, char *argv[])
         close_serial();
     }
 
-    if (open_serial(device_name, BAUD_RATE, &dummy)<0)
+    if (open_serial(device_name, 57600, &dummy)<0)
         return 1;
 
-    if (speed != BAUD_RATE)
+    if (speed != 57600)
         change_speed(device_name, speed);
 
     switch (command) {


### PR DESCRIPTION
This patch reflects the proposed fix @pcercuei gave for issue #10. 
I've tested recompiling the host tool with `57600`, `115200`, and `1500000` and it now gives the intended behavior. Thanks @pcercuei !

Someone who is more familiar with this code should verify that this is correct method to fix. 