### PR TITLE
Add support for passing Exit Return code from Target to Host

### DIFF
--- a/Makefile.cfg
+++ b/Makefile.cfg
@@ -89,7 +89,7 @@ endif
 # You generally shouldn't change this unless you are making forked
 # versions (or test versions)
 # Version numbers must be of the form x.x.x
-VERSION = 1.0.6
+VERSION = 1.0.7
 
 # Define this if you want a standalone, statically linked, no dependency binary
 #STANDALONE_BINARY = 1

--- a/host-src/tool/dc-io.h
+++ b/host-src/tool/dc-io.h
@@ -5,5 +5,6 @@ int send_uint(unsigned int value);
 unsigned int recv_uint(void);
 void recv_data(void *data, unsigned int total, unsigned int verbose);
 void send_data(unsigned char *addr, unsigned int size, unsigned int verbose);
+void finish_serial(void);
 
 #endif /* __DC_IO_H__ */

--- a/host-src/tool/dc-tool.c
+++ b/host-src/tool/dc-tool.c
@@ -1143,8 +1143,7 @@ void do_console(unsigned char *path, unsigned char *isofile) {
 
         switch(command) {
             case 0:
-                finish_serial();
-                exit(0);
+                dc_exit();
                 break;
             case 1:
                 dc_fstat();

--- a/host-src/tool/dc-tool.c
+++ b/host-src/tool/dc-tool.c
@@ -1141,7 +1141,8 @@ void do_console(unsigned char *path, unsigned char *isofile) {
 
         switch(command) {
             case 0:
-                dc_exit();
+                finish_serial();
+                exit(0);
                 break;
             case 1:
                 dc_fstat();
@@ -1206,6 +1207,9 @@ void do_console(unsigned char *path, unsigned char *isofile) {
             case 21:
                 dc_rewinddir();
                 break;
+            case 22:
+                dc_exit();
+                break;
             default:
                 printf("Unimplemented command (%d) \n", command);
                 printf("Assuming program has exited, or something...\n");
@@ -1262,7 +1266,7 @@ int main(int argc, char *argv[]) {
 
     if (argc < 2) {
         usage();
-	exit(-1);
+        exit(-1);
     }
     someopt = getopt(argc, argv, AVAILABLE_OPTIONS);
     while(someopt > 0) {
@@ -1330,7 +1334,7 @@ int main(int argc, char *argv[]) {
                 break;
             case 'h':
                 usage();
-		exit(0);
+                exit(0);
                 break;
             case 'e':
                 speedhack = 1;

--- a/host-src/tool/dc-tool.c
+++ b/host-src/tool/dc-tool.c
@@ -858,8 +858,6 @@ void usage(void) {
     printf("-g            Start a GDB server\n");
     printf("-h            Usage information (you\'re looking at it)\n\n");
     cleanup();
-
-    exit(0);
 }
 
 /* Got to make sure WinSock is initalized */
@@ -1212,7 +1210,7 @@ void do_console(unsigned char *path, unsigned char *isofile) {
                 printf("Unimplemented command (%d) \n", command);
                 printf("Assuming program has exited, or something...\n");
                 finish_serial();
-                exit(0);
+                exit(-1);
                 break;
         }
     }
@@ -1262,16 +1260,17 @@ int main(int argc, char *argv[]) {
     unsigned char *isofile = 0;
     int someopt;
 
-    if(argc < 2)
+    if (argc < 2) {
         usage();
-
+	exit(-1);
+    }
     someopt = getopt(argc, argv, AVAILABLE_OPTIONS);
     while(someopt > 0) {
         switch(someopt) {
             case 'x':
                 if(command) {
                     printf("You can only specify one of -x, -u, and -d\n");
-                    exit(0);
+                    exit(-1);
                 }
                 command = 'x';
                 filename = malloc(strlen(optarg) + 1);
@@ -1280,7 +1279,7 @@ int main(int argc, char *argv[]) {
             case 'u':
                 if(command) {
                     printf("You can only specify one of -x, -u, and -d\n");
-                    exit(0);
+                    exit(-1);
                 }
                 command = 'u';
                 filename = malloc(strlen(optarg) + 1);
@@ -1289,7 +1288,7 @@ int main(int argc, char *argv[]) {
             case 'd':
                 if(command) {
                     printf("You can only specify one of -x, -u, and -d\n");
-                    exit(0);
+                    exit(-1);
                 }
                 command = 'd';
                 filename = malloc(strlen(optarg) + 1);
@@ -1331,6 +1330,7 @@ int main(int argc, char *argv[]) {
                 break;
             case 'h':
                 usage();
+		exit(0);
                 break;
             case 'e':
                 speedhack = 1;
@@ -1358,7 +1358,7 @@ int main(int argc, char *argv[]) {
         struct stat statbuf;
         if(stat((char *)filename, &statbuf)) {
             perror((char *)filename);
-            exit(1);
+            exit(-1);
         }
     }
 
@@ -1426,7 +1426,7 @@ int main(int argc, char *argv[]) {
             if(!size) {
                 printf("You must specify a size (-s <size>) with download (-d <filename>)\n");
                 cleanup();
-                exit(0);
+                exit(-1);
             }
             printf("Download %d bytes at <0x%x> to <%s>\n", size, address,
                 filename);
@@ -1438,6 +1438,7 @@ int main(int argc, char *argv[]) {
                 do_dumbterm();
             else
                 usage();
+	    	exit(-1);
             break;
     }
 

--- a/host-src/tool/syscalls.c
+++ b/host-src/tool/syscalls.c
@@ -553,3 +553,11 @@ void dc_gdbpacket(void) {
     if(retval > 0)
         send_data((unsigned char *)gdb_buf, retval, 0);
 }
+
+void dc_exit(void) {
+    int exit_code = (int32_t) recv_uint();
+    printf("Program returned %d\n", exit_code);
+    finish_serial();
+    exit(exit_code);
+}
+

--- a/host-src/tool/syscalls.h
+++ b/host-src/tool/syscalls.h
@@ -46,4 +46,6 @@ void dc_cdfs_redir_read_sectors(int isofd);
 
 void dc_gdbpacket(void);
 
+_Noreturn void dc_exit(void);
+
 #endif

--- a/target-src/dcload/syscalls.c
+++ b/target-src/dcload/syscalls.c
@@ -44,8 +44,10 @@ int strlen(const char *s) {
     return c;
 }
 
-void dcexit(void) {
+void dcexit(int ret_code)
+{
     scif_putchar(0);
+    put_uint(ret_code);
     scif_flush();
 }
 

--- a/target-src/dcload/syscalls.c
+++ b/target-src/dcload/syscalls.c
@@ -44,9 +44,8 @@ int strlen(const char *s) {
     return c;
 }
 
-void dcexit(int ret_code)
-{
-    scif_putchar(0);
+void dcexit(int ret_code) {
+    scif_putchar(22);
     put_uint(ret_code);
     scif_flush();
 }


### PR DESCRIPTION
Adds support for receiving the return code passed to the exit() syscall that was added to KOS in https://github.com/KallistiOS/KallistiOS/commit/596f2bcb7907730334d16a44cba629944b008824. The value will be passed back over the serial connection to the host program which will use it as its return code when exiting. 

I also changed some other exit codes to help determine when a failure has actually occurred in order to avoid false positives when using this change to detect passing or failing of software on the target.