### PR TITLE
dc-tool.c: add variable declaration for new variable "oldspeed"

### DIFF
--- a/host-src/tool/dc-tool.c
+++ b/host-src/tool/dc-tool.c
@@ -605,6 +605,7 @@ int open_serial(char *devicename, unsigned int speed, unsigned int *speedtest) {
     *speedtest = speed;
 #ifndef _WIN32
     speed_t baudconst;
+    unsigned int oldspeed;
 
     dcfd = open(devicename, O_RDWR | O_NOCTTY);
     if(dcfd < 0) {


### PR DESCRIPTION
fix for missing variable (oldspeed) declaration that was added in previous merge request