### PR TITLE
Ported 2 Bugfixes/Enhancements from DCLoad-IP

### DIFF
--- a/host-src/tool/dc-tool.c
+++ b/host-src/tool/dc-tool.c
@@ -784,6 +784,17 @@ int open_gdb_socket(int port) {
         perror("error creating gdb server socket");
         return -1;
     }
+
+    const int enable_reuse_addr = 1;
+    int checkopt = setsockopt(gdb_server_socket, SOL_SOCKET, SO_REUSEADDR,
+                              &enable_reuse_addr, sizeof(enable_reuse_addr));
+#ifdef __MINGW32__
+    if( checkopt == SOCKET_ERROR ) {
+#else
+    if( checkopt < 0 ) {
+#endif
+        log_error( "warning: failed to set gdb socket options" );
+    }
     
     int checkbind = bind(gdb_server_socket, (struct sockaddr*)&server_addr, sizeof(server_addr));
 #ifdef __MINGW32__

--- a/host-src/tool/dc-tool.c
+++ b/host-src/tool/dc-tool.c
@@ -793,7 +793,7 @@ int open_gdb_socket(int port) {
 #else
     if( checkopt < 0 ) {
 #endif
-        log_error( "warning: failed to set gdb socket options" );
+        perror( "warning: failed to set gdb socket options" );
     }
     
     int checkbind = bind(gdb_server_socket, (struct sockaddr*)&server_addr, sizeof(server_addr));

--- a/host-src/tool/syscalls.c
+++ b/host-src/tool/syscalls.c
@@ -27,6 +27,7 @@
 #include <string.h>
 #include <errno.h>
 #include <sys/time.h>
+#include <time.h>
 #include <unistd.h>
 #include <utime.h>
 #include <dirent.h>

--- a/host-src/tool/syscalls.c
+++ b/host-src/tool/syscalls.c
@@ -25,6 +25,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <errno.h>
 #include <sys/time.h>
 #include <unistd.h>
 #include <utime.h>
@@ -505,6 +506,11 @@ void dc_gdbpacket(void) {
 #ifdef __MINGW32__
     if(retval == SOCKET_ERROR) {
         fprintf(stderr, "Got socket error: %d\n", WSAGetLastError());
+        return;
+    }
+#else
+    if(retval == -1) {
+        fprintf(stderr, "Got socket error: %s\n", strerror(errno));
         return;
     }
 #endif


### PR DESCRIPTION
1) dcload-ip commit ID 6522d8089593690852b3685be2b5f5d9222ad796:
- Previously, if you had completed a debugging session and had started a
  new one too quickly, you could very frequently get the error "error
binding gdb server socket" which would also freeze the DC, making it
need a hard reboot
- This is because the OS hadn't had a chance to terminate the existing
  socket bound to the existing address
- This commit sets the socket to allow for reuse of local addresses

2) dcload-ip commit ID 871419616992ce86d0437b5b3a80fc3925ebdab7:
- Fixed crash on GDB disconnect.
- We were getting a -1 from recv(), which we were then passing on to
  send_command(), which was causing a buffer overflow and crash. It
seems as though MinGW might be protected from this.