### PR TITLE
Fix configuration for aarch64 Mac

### DIFF
--- a/Makefile.cfg
+++ b/Makefile.cfg
@@ -9,6 +9,13 @@ HOSTCC			= gcc
 HOSTCFLAGS		= -O2 -I/usr/local/include
 HOSTLDFLAGS		= -L/usr/local/lib
 
+ifdef MACOS
+  ifeq ($(shell uname -m),arm64)
+    HOSTCFLAGS              = -O2 -I/opt/homebrew/include
+    HOSTLDFLAGS             = -L/opt/homebrew/lib
+  endif
+endif
+
 # For MinGW/MSYS, MinGW-w64/MSYS2 and Cygwin
 ifdef WINDOWS
   HOSTCFLAGS += -D_WIN32
@@ -48,7 +55,11 @@ ELFINCLUDE		= $(TARGETPREFIX)/include
 
 # For macOS, libelf is here when installed through Homebrew
 ifdef MACOS
-  ELFINCLUDE	= /usr/local/include/libelf
+  ifeq ($(shell uname -m),arm64)
+    ELFINCLUDE	= /opt/homebrew/include/libelf
+  else
+    ELFINCLUDE	= /usr/local/include/libelf
+  endif
 endif
 
 # sh-elf-stuff


### PR DESCRIPTION
The Homebrew package manager has different paths on arm64 vs. intel. This allows dcload-serial to build on arm64 Macs. 