### PR TITLE
Backport changes from KOSU fork

### DIFF
--- a/Makefile.cfg
+++ b/Makefile.cfg
@@ -5,14 +5,14 @@ ROOTDIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 include $(ROOTDIR)/Makefile.hostdetect
 
 # Host compiler and flags
-HOSTCC			= gcc
+HOSTCC			  = gcc
 HOSTCFLAGS		= -O2 -I/usr/local/include
 HOSTLDFLAGS		= -L/usr/local/lib
 
 ifdef MACOS
   ifeq ($(shell uname -m),arm64)
-    HOSTCFLAGS              = -O2 -I/opt/homebrew/include
-    HOSTLDFLAGS             = -L/opt/homebrew/lib
+    HOSTCFLAGS    = -O2 -I/opt/homebrew/include
+    HOSTLDFLAGS   = -L/opt/homebrew/lib
   endif
 endif
 
@@ -24,7 +24,7 @@ endif
 
 # dc compiler prefix -- this is usually what you used for --prefix when
 # building your compiler.
-TARGETPREFIX	= /opt/toolchains/dc/sh-elf
+TARGETPREFIX	  = /opt/toolchains/dc/sh-elf
 
 # dir to install dc-tool in
 TOOLINSTALLDIR	= /opt/toolchains/dc/bin
@@ -46,12 +46,12 @@ endif
 # If you built your Sega Dreamcast toolchains with dc-chain, you'll have it
 # installed in the correct location.
 BFDLIB			= $(TARGETPREFIX)/lib
-BFDINCLUDE		= $(TARGETPREFIX)/include
+BFDINCLUDE	= $(TARGETPREFIX)/include
 
 # When using libelf instead of BFD, these must point to your
 # libelf installation (leave empty or undefined if libelf is part of the system)
 ELFLIB			= $(TARGETPREFIX)/lib
-ELFINCLUDE		= $(TARGETPREFIX)/include
+ELFINCLUDE	= $(TARGETPREFIX)/include
 
 # For macOS, libelf is here when installed through Homebrew
 ifdef MACOS
@@ -64,10 +64,10 @@ endif
 
 # sh-elf-stuff
 # You don't need to change these
-TARGETCC		= $(TARGETPREFIX)/bin/sh-elf-gcc
+TARGETCC		  = $(TARGETPREFIX)/bin/sh-elf-gcc
 TARGETCFLAGS	= -O2 -ml -m4-single-only
 TARGETOBJCOPY	= $(TARGETPREFIX)/bin/sh-elf-objcopy -R .stack
-TARGETLD		= $(TARGETPREFIX)/bin/sh-elf-ld
+TARGETLD		  = $(TARGETPREFIX)/bin/sh-elf-ld
 
 # set TARGETCCVER to 3 or 4, depending on your SH compiler version (gcc 3.x or gcc 4.x)
 # this line tries to detect the version automatically
@@ -75,7 +75,7 @@ TARGETLD		= $(TARGETPREFIX)/bin/sh-elf-ld
 # if version > 4 then it's 4
 TARGETCCVER		= $(shell $(TARGETCC) --version | head -1 | sed  "s/.* \([[:digit:]][[:digit:]]*\)\.[[:digit:]][[:digit:]]*.*/\1/")
 ifeq ($(shell test $(TARGETCCVER) -gt 4; echo $$?),0)
-  TARGETCCVER   = 4
+  TARGETCCVER  = 4
 endif
 
 # You generally shouldn't change this unless you are making forked

--- a/README.md
+++ b/README.md
@@ -143,3 +143,6 @@ To run a GNU debugger session over the **dcload** connection:
 * Fixes for `libbfd` segfaults by **Atani**.
 * Tons of improvements and fixes by [SiZiOUS](https://sizious.com).
 * Modern macOS testing by [Ben Baron a.k.a. einsteinx2](https://twitter.com/einsteinx2).
+* Bugfixes, rewinddir, custom baud rates for macOS and code sanitization
+  backported from KOSU fork by [andressbarajas](https://github.com/andressbarajas)
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# dcload-serial 1.0.6
+# dcload-serial 1.0.6-hostfix1
 
 **dcload** is a **Sega Dreamcast** (DC) serial loader written originally by 
 [Andrew Kieschnick](http://napalm-x.thegypsy.com/andrewk/dc/), a.k.a.
@@ -144,5 +144,5 @@ To run a GNU debugger session over the **dcload** connection:
 * Tons of improvements and fixes by [SiZiOUS](https://sizious.com).
 * Modern macOS testing by [Ben Baron a.k.a. einsteinx2](https://twitter.com/einsteinx2).
 * Bugfixes, rewinddir, custom baud rates for macOS and code sanitization
-  backported from KOSU fork by [andressbarajas](https://github.com/andressbarajas)
+  backported from KOSU fork by [andressbarajas](https://github.com/andressbarajas).
 

--- a/example-src/dcload-syscalls.c
+++ b/example-src/dcload-syscalls.c
@@ -1,5 +1,9 @@
 #include "dcload-syscall.h"
 
+#include <sys/stat.h>
+
+extern void __exit(int status);
+
 int link(const char *oldpath, const char *newpath) {
     if(*DCLOADMAGICADDR == DCLOADMAGICVALUE)
         return dcloadsyscall(pclinknr, oldpath, newpath);
@@ -63,11 +67,13 @@ int unlink(const char *path) {
         return -1;
 }
 
-void exit(int status) {
+void __attribute__((noreturn)) exit(int status) {
     if(*DCLOADMAGICADDR == DCLOADMAGICVALUE)
         dcloadsyscall(pcexitnr);
 
     __exit(status);
+    /* Ensure function never returns */
+    for(;;) {}
 }
 
 int stat(const char *path, struct stat *st) {
@@ -77,7 +83,7 @@ int stat(const char *path, struct stat *st) {
         return -1;
 }
 
-int chmod(const char *path, short mode) {
+int chmod(const char *path, unsigned int mode) {
     if(*DCLOADMAGICADDR == DCLOADMAGICVALUE)
         return dcloadsyscall(pcchmodnr, path, mode);
     else

--- a/example-src/dcload-syscalls.h
+++ b/example-src/dcload-syscalls.h
@@ -1,6 +1,9 @@
 #ifndef __DCLOAD_SYSCALLS_H__
 #define __DCLOAD_SYSCALLS_H__
 
+/* Forward declaration of struct stat */
+struct stat;
+
 #define O_RDONLY        0
 #define O_WRONLY        1
 #define O_RDWR          2
@@ -14,9 +17,9 @@ int fstat(int file, struct stat *st);
 int open(const char *path, int flags);
 int creat(const char *path, int mode);
 int unlink(const char *path);
-void exit(int status);
+void __attribute__((noreturn)) exit(int status);
 int stat(const char *path, struct stat *st);
-int chmod(const char *path, short mode);
+int chmod(const char *path, unsigned int mode);
 int utime(const char *path, char *times);
 int chdir(const char *path);
 long time(long *t);

--- a/host-src/tool/Makefile
+++ b/host-src/tool/Makefile
@@ -24,11 +24,11 @@ ifeq ($(WITH_BFD),1)
   ifneq ("$(wildcard $(TARGETPREFIX)/lib/libsframe.a)","")
     LIBSFRAME = -lsframe
   endif
-  
+
   CFLAGS	+= -DWITH_BFD
   LDFLAGS	+= -L$(BFDLIB) -lbfd $(LIBSFRAME) -liberty -lintl
   INCLUDE	+= -I$(BFDINCLUDE)
-  
+
   ZLIB_REQUIRED := 1
 else
   LDFLAGS	+= -L$(ELFLIB) -lelf
@@ -60,7 +60,7 @@ $(DCTOOL): $(OBJECTS)
 	$(CC) -o $@ $(OBJECTS) $(LDFLAGS)
 
 minilzo.o: $(LZOFILES)
-	$(CC) $(CFLAGS) $(INCLUDE) -o $@ -c $< 
+	$(CC) $(CFLAGS) $(INCLUDE) -o $@ -c $<
 
 .PHONY : install
 install: $(DCTOOL) | $(TOOLINSTALLDIR)

--- a/host-src/tool/config.h
+++ b/host-src/tool/config.h
@@ -2,7 +2,7 @@
 #ifndef __CONFIG_H__
 #define __CONFIG_H__
 
-#define PACKAGE                 "dc-tool" 
-#define PACKAGE_VERSION 	DCLOAD_VERSION
+#define PACKAGE           "dc-tool"
+#define PACKAGE_VERSION   DCLOAD_VERSION
 
 #endif /* __CONFIG_H__ */

--- a/host-src/tool/dc-io.h
+++ b/host-src/tool/dc-io.h
@@ -7,5 +7,3 @@ void recv_data(void *data, unsigned int total, unsigned int verbose);
 void send_data(unsigned char *addr, unsigned int size, unsigned int verbose);
 
 #endif
-
-

--- a/host-src/tool/shim.c
+++ b/host-src/tool/shim.c
@@ -17,20 +17,20 @@
  *
  */
 
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
 
 #ifdef __MINGW32__
 #include <_mingw.h>
 #include <windows.h>
 
 /* Detect MinGW/MSYS vs. MinGW-w64/MSYS2 */
-# ifdef __MINGW64_VERSION_MAJOR
-#  define __RT_MINGW_W64__
-# else
-#  define __RT_MINGW_ORG__
-# endif
+#ifdef __MINGW64_VERSION_MAJOR
+#define __RT_MINGW_W64__
+#else
+#define __RT_MINGW_ORG__
+#endif
 
 #endif /* __MINGW32__ */
 
@@ -47,28 +47,27 @@
 #ifdef __RT_MINGW_ORG__
 
 // See: https://github.com/mingw-w64/mingw-w64/blob/master/mingw-w64-crt/stdio/mingw_vasprintf.c
-int vasprintf(char ** __restrict__ ret,
-              const char * __restrict__ format,
-              va_list ap) {
-  int len;
-  /* Get Length */
-  len = __mingw_vsnprintf(NULL,0,format,ap);
-  if (len < 0) return -1;
-  /* +1 for \0 terminator. */
-  *ret = malloc(len + 1);
-  /* Check malloc fail*/
-  if (!*ret) return -1;
-  /* Write String */
-  __mingw_vsnprintf(*ret,len+1,format,ap);
-  /* Terminate explicitly */
-  (*ret)[len] = '\0';
-  return len;
+int vasprintf(char **__restrict__ ret, const char *__restrict__ format, va_list ap) {
+    int len;
+    /* Get Length */
+    len = __mingw_vsnprintf(NULL, 0, format, ap);
+    if(len < 0)
+        return -1;
+    /* +1 for \0 terminator. */
+    *ret = malloc(len + 1);
+    /* Check malloc fail*/
+    if(!*ret)
+        return -1;
+    /* Write String */
+    __mingw_vsnprintf(*ret, len + 1, format, ap);
+    /* Terminate explicitly */
+    (*ret)[len] = '\0';
+    return len;
 }
 
 // Thanks to Dietrich Epp
 // See: https://stackoverflow.com/a/40160038
-int __cdecl __MINGW_NOTHROW libintl_asprintf(char **strp, 
-                                             const char *fmt, ...) {
+int __cdecl __MINGW_NOTHROW libintl_asprintf(char **strp, const char *fmt, ...) {
     va_list ap;
     va_start(ap, fmt);
 
@@ -78,30 +77,30 @@ int __cdecl __MINGW_NOTHROW libintl_asprintf(char **strp,
     return r;
 }
 
-int __cdecl __MINGW_NOTHROW libintl_vasprintf(char **restrict strp,
-                                              const char *restrict fmt,
-                                              va_list arg ) {
-	return vasprintf(strp, fmt, arg);
+int __cdecl __MINGW_NOTHROW libintl_vasprintf(char **restrict strp, const char *restrict fmt,
+                                              va_list arg) {
+    return vasprintf(strp, fmt, arg);
 }
 
 // See: https://stackoverflow.com/a/60380005
-int __cdecl __MINGW_NOTHROW __ms_vsnprintf(char *buffer,
-                                           size_t count,
-                                           const char *format,
+int __cdecl __MINGW_NOTHROW __ms_vsnprintf(char *buffer, size_t count, const char *format,
                                            va_list argptr) {
-	return __mingw_vsnprintf(buffer, count, format, argptr);
+    return __mingw_vsnprintf(buffer, count, format, argptr);
 }
 
 // Thanks to Kenji Uno and god
 // See: https://github.com/HiraokaHyperTools/libacrt_iob_func
 // See: https://stackoverflow.com/a/30894349
-FILE * __cdecl __MINGW_NOTHROW _imp____acrt_iob_func(int handle) {
-    switch (handle) {
-        case 0: return stdin;
-        case 1: return stdout;
-        case 2: return stderr;
+FILE *__cdecl __MINGW_NOTHROW _imp____acrt_iob_func(int handle) {
+    switch(handle) {
+    case 0:
+        return stdin;
+    case 1:
+        return stdout;
+    case 2:
+        return stderr;
     }
-    
+
     return NULL;
 }
 

--- a/host-src/tool/unlink.c
+++ b/host-src/tool/unlink.c
@@ -1,6 +1,6 @@
+#include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include <sys/stat.h>
 
 #ifndef S_ISLNK
 #ifdef S_IFLNK
@@ -11,12 +11,11 @@
 #endif
 #endif
 
-int unlink_if_ordinary (const char *name) {
+int unlink_if_ordinary(const char *name) {
     struct stat st;
 
-    if(lstat (name, &st) == 0 && 
-      (S_ISREG (st.st_mode) || S_ISLNK (st.st_mode))) {
-        return unlink (name);
+    if(lstat(name, &st) == 0 && (S_ISREG(st.st_mode) || S_ISLNK(st.st_mode))) {
+        return unlink(name);
     }
 
     return 1;

--- a/target-src/dcload/Makefile
+++ b/target-src/dcload/Makefile
@@ -4,7 +4,7 @@ LZOPATH = ../../minilzo-2.10
 LZO	= ../../host-src/misc/lzo
 
 CC	= $(TARGETCC)
-CFLAGS	= $(TARGETCFLAGS) -DDCLOAD_VERSION=\"$(VERSION)\"
+CFLAGS	= $(TARGETCFLAGS) -Wno-builtin-declaration-mismatch -DDCLOAD_VERSION=\"$(VERSION)\"
 INCLUDE	= -I$(LZOPATH) -I../../target-inc
 
 OBJCOPY	= $(TARGETOBJCOPY)
@@ -15,16 +15,16 @@ EXCOBJECTS	= exception.o
 LZOFILES = $(LZOPATH)/minilzo.c $(LZOPATH)/minilzo.h $(LZOPATH)/lzoconf.h
 
 .c.o:
-	$(CC) $(CFLAGS) $(INCLUDE) -o $@ -c $< 
+	$(CC) $(CFLAGS) $(INCLUDE) -o $@ -c $<
 .s.o:
-	$(CC) $(CFLAGS) $(INCLUDE) -o $@ -c $< 
+	$(CC) $(CFLAGS) $(INCLUDE) -o $@ -c $<
 .S.o:
-	$(CC) $(CFLAGS) $(INCLUDE) -o $@ -c $< 
+	$(CC) $(CFLAGS) $(INCLUDE) -o $@ -c $<
 
 all: dcload.lzo exception.lzo
 
 dcload.lzo: dcload.bin
-	$(LZO) $< $@	
+	$(LZO) $< $@
 
 dcload.bin: dcload
 	$(OBJCOPY) -R .stack -O binary $< $@
@@ -33,21 +33,21 @@ dcload: $(DCLOBJECTS)
 	$(CC) $(CFLAGS) -Wl,-Tdcload.x -nostartfiles -nostdlib $^ -o $@ -lgcc
 
 exception.lzo: exception.bin
-	$(LZO) $< $@	
+	$(LZO) $< $@
 
 exception.bin: exception
-	$(OBJCOPY) -O binary $< $@	
+	$(OBJCOPY) -O binary $< $@
 
 exception: $(EXCOBJECTS)
 	$(CC) $(CFLAGS) -Wl,-Ttext=0x8c00f400 -nostartfiles -nostdlib $^ -o $@
 
 minilzo.o: $(LZOFILES)
-	$(CC) $(CFLAGS) $(INCLUDE) -o $@ -c $< 
+	$(CC) $(CFLAGS) $(INCLUDE) -o $@ -c $<
 
 .PHONY : clean
 clean:
 	-rm -f $(DCLOBJECTS) $(EXCOBJECTS) dcload exception dcload.bin exception.bin
 
 .PHONY : distclean
-distclean: clean 
+distclean: clean
 	-rm -f *.lzo

--- a/target-src/dcload/cdfs_syscalls.c
+++ b/target-src/dcload/cdfs_syscalls.c
@@ -1,4 +1,4 @@
-/* 
+/*
  * This file is part of the dcload Dreamcast serial loader
  *
  * Copyright (C) 2001 Andrew Kieschnick <andrewk@napalm-x.com>
@@ -22,8 +22,8 @@
 #include "scif.h"
 
 extern void load_data_block_general(unsigned char *addr,
-                                         unsigned int size, unsigned int verbose);
-extern unsigned int send_data_block_compressed(unsigned char * addr,
+                                    unsigned int size, unsigned int verbose);
+extern unsigned int send_data_block_compressed(unsigned char *addr,
                                                unsigned int size);
 extern unsigned int get_uint(void);
 extern int put_uint(unsigned int val);
@@ -40,34 +40,34 @@ int gdGdcReqCmd(int cmd, int *param) {
     struct TOC *toc;
     int i;
 
-    switch (cmd) {
-        case 16: /* read sectors */
-            scif_putchar(19);
-            put_uint(param[0]); /* starting sector */
-            put_uint(param[1]); /* number of sectors */
-            load_data_block_general((unsigned char *)param[2], param[1]*2048, 0);
-            param[3] = 0;
-            gdStatus = 2;
-            return 0;
-        case 19: /* read toc */
-            toc = (struct TOC *)param[1];
-            toc->entry[0] = 0x41000096; /* CTRL = 4, ADR = 1, LBA = 150 */
-            for(i=1; i<99; i++)
-                toc->entry[i] = -1;
-            toc->first = 0x41010000; /* first = track 1 */
-            toc->last = 0x41010000; /* last = track 1 */
-            gdStatus = 2;
-            return 0;
-        case 24: /* init disc */
-            gdStatus = 2;
-            return 0;
-        default:
-            gdStatus = 0;
-            return -1;
+    switch(cmd) {
+    case 16: /* read sectors */
+        scif_putchar(19);
+        put_uint(param[0]); /* starting sector */
+        put_uint(param[1]); /* number of sectors */
+        load_data_block_general((unsigned char *)param[2], param[1] * 2048, 0);
+        param[3] = 0;
+        gdStatus = 2;
+        return 0;
+    case 19: /* read toc */
+        toc = (struct TOC *)param[1];
+        toc->entry[0] = 0x41000096; /* CTRL = 4, ADR = 1, LBA = 150 */
+        for (i = 1; i < 99; i++)
+            toc->entry[i] = -1;
+        toc->first = 0x41010000; /* first = track 1 */
+        toc->last = 0x41010000;  /* last = track 1 */
+        gdStatus = 2;
+        return 0;
+    case 24: /* init disc */
+        gdStatus = 2;
+        return 0;
+    default:
+        gdStatus = 0;
+        return -1;
     }
 }
 
-void gdGdcExecServer(void) { }
+void gdGdcExecServer(void) {}
 
 int gdGdcGetCmdStat(int f, int *status) {
     if(gdStatus == 0)
@@ -84,5 +84,4 @@ int gdGdcChangeDataType(int *param) {
     return 0;
 }
 
-void gdGdcInitSystem(void) { }
-
+void gdGdcInitSystem(void) {}

--- a/target-src/dcload/memcmp.c
+++ b/target-src/dcload/memcmp.c
@@ -1,59 +1,56 @@
 /*
-FUNCTION
-    <<memcmp>>---compare two memory areas
+    FUNCTION
+        <<memcmp>>---compare two memory areas
 
-INDEX
-    memcmp
+    INDEX
+        memcmp
 
-ANSI_SYNOPSIS
-    #include <string.h>
-    int memcmp(const void *<[s1]>, const void *<[s2]>, size_t <[n]>);
+    ANSI_SYNOPSIS
+        #include <string.h>
+        int memcmp(const void *<[s1]>, const void *<[s2]>, size_t <[n]>);
 
-TRAD_SYNOPSIS
-    #include <string.h>
-    int memcmp(<[s1]>, <[s2]>, <[n]>)
-    void *<[s1]>;
-    void *<[s2]>;
-    size_t <[n]>;
+    TRAD_SYNOPSIS
+        #include <string.h>
+        int memcmp(<[s1]>, <[s2]>, <[n]>)
+        void *<[s1]>;
+        void *<[s2]>;
+        size_t <[n]>;
 
-DESCRIPTION
-    This function compares not more than <[n]> characters of the
-    object pointed to by <[s1]> with the object pointed to by <[s2]>.
+    DESCRIPTION
+        This function compares not more than <[n]> characters of the
+        object pointed to by <[s1]> with the object pointed to by <[s2]>.
 
 
-RETURNS
-    The function returns an integer greater than, equal to or
-    less than zero 	according to whether the object pointed to by
-    <[s1]> is greater than, equal to or less than the object
-    pointed to by <[s2]>.
+    RETURNS
+        The function returns an integer greater than, equal to or
+        less than zero 	according to whether the object pointed to by
+        <[s1]> is greater than, equal to or less than the object
+        pointed to by <[s2]>.
 
-PORTABILITY
-<<memcmp>> is ANSI C.
+    PORTABILITY
+    <<memcmp>> is ANSI C.
 
-<<memcmp>> requires no supporting OS subroutines.
+    <<memcmp>> requires no supporting OS subroutines.
 
-QUICKREF
-    memcmp ansi pure
+    QUICKREF
+        memcmp ansi pure
 */
 
 #include <string.h>
 
 /* Nonzero if either X or Y is not aligned on a "long" boundary.  */
-#define UNALIGNED(X, Y) \
-  (((long)X & (sizeof (long) - 1)) | ((long)Y & (sizeof (long) - 1)))
+#define UNALIGNED(X, Y) (((long)X & (sizeof(long) - 1)) | ((long)Y & (sizeof(long) - 1)))
 
 /* How many bytes are copied each iteration of the word copy loop.  */
-#define LBLOCKSIZE (sizeof (long))
+#define LBLOCKSIZE (sizeof(long))
 
 /* Threshhold for punting to the byte copier.  */
-#define TOO_SMALL(LEN)  ((LEN) < LBLOCKSIZE)
+#define TOO_SMALL(LEN) ((LEN) < LBLOCKSIZE)
 
-int
-_DEFUN(memcmp, (m1, m2, n),
-       _CONST _PTR m1 _AND _CONST _PTR m2 _AND size_t n) {
+int _DEFUN(memcmp, (m1, m2, n), _CONST _PTR m1 _AND _CONST _PTR m2 _AND size_t n) {
 #if defined(PREFER_SIZE_OVER_SPEED) || defined(__OPTIMIZE_SIZE__)
-    unsigned char *s1 = (unsigned char *) m1;
-    unsigned char *s2 = (unsigned char *) m2;
+    unsigned char *s1 = (unsigned char *)m1;
+    unsigned char *s2 = (unsigned char *)m2;
 
     while(n--) {
         if(*s1 != *s2) {
@@ -64,8 +61,8 @@ _DEFUN(memcmp, (m1, m2, n),
     }
     return 0;
 #else
-    unsigned char *s1 = (unsigned char *) m1;
-    unsigned char *s2 = (unsigned char *) m2;
+    unsigned char *s1 = (unsigned char *)m1;
+    unsigned char *s2 = (unsigned char *)m2;
     unsigned long *a1;
     unsigned long *a2;
 
@@ -73,12 +70,12 @@ _DEFUN(memcmp, (m1, m2, n),
        then we punt to the byte compare loop.  Hopefully this will
        not turn up in inner loops.  */
     if(!TOO_SMALL(n) && !UNALIGNED(s1, s2)) {
-        /* Otherwise, load and compare the blocks of memory one 
+        /* Otherwise, load and compare the blocks of memory one
         word at a time.  */
-        a1 = (unsigned long *) s1;
-        a2 = (unsigned long *) s2;
+        a1 = (unsigned long *)s1;
+        a2 = (unsigned long *)s2;
         while(n >= LBLOCKSIZE) {
-            if (*a1 != *a2)
+            if(*a1 != *a2)
                 break;
             a1++;
             a2++;
@@ -87,8 +84,8 @@ _DEFUN(memcmp, (m1, m2, n),
 
         /* check m mod LBLOCKSIZE remaining characters */
 
-        s1 = (char *) a1;
-        s2 = (char *) a2;
+        s1 = (char *)a1;
+        s2 = (char *)a2;
     }
 
     while(n--) {
@@ -99,5 +96,5 @@ _DEFUN(memcmp, (m1, m2, n),
     }
 
     return 0;
-#endif				/* not PREFER_SIZE_OVER_SPEED */
+#endif /* not PREFER_SIZE_OVER_SPEED */
 }

--- a/target-src/dcload/memmove.c
+++ b/target-src/dcload/memmove.c
@@ -1,62 +1,60 @@
 /*
-FUNCTION
-    <<memmove>>---move possibly overlapping memory
+    FUNCTION
+        <<memmove>>---move possibly overlapping memory
 
-INDEX
-    memmove
+    INDEX
+        memmove
 
-ANSI_SYNOPSIS
-    #include <string.h>
-    void *memmove(void *<[dst]>, const void *<[src]>, size_t <[length]>);
+    ANSI_SYNOPSIS
+        #include <string.h>
+        void *memmove(void *<[dst]>, const void *<[src]>, size_t <[length]>);
 
-TRAD_SYNOPSIS
-    #include <string.h>
-    void *memmove(<[dst]>, <[src]>, <[length]>)
-    void *<[dst]>;
-    void *<[src]>;
-    size_t <[length]>;
+    TRAD_SYNOPSIS
+        #include <string.h>
+        void *memmove(<[dst]>, <[src]>, <[length]>)
+        void *<[dst]>;
+        void *<[src]>;
+        size_t <[length]>;
 
-DESCRIPTION
-    This function moves <[length]> characters from the block of
-    memory starting at <<*<[src]>>> to the memory starting at
-    <<*<[dst]>>>. <<memmove>> reproduces the characters correctly
-    at <<*<[dst]>>> even if the two areas overlap.
+    DESCRIPTION
+        This function moves <[length]> characters from the block of
+        memory starting at <<*<[src]>>> to the memory starting at
+        <<*<[dst]>>>. <<memmove>> reproduces the characters correctly
+        at <<*<[dst]>>> even if the two areas overlap.
 
 
-RETURNS
-    The function returns <[dst]> as passed.
+    RETURNS
+        The function returns <[dst]> as passed.
 
-PORTABILITY
-<<memmove>> is ANSI C.
+    PORTABILITY
+    <<memmove>> is ANSI C.
 
-<<memmove>> requires no supporting OS subroutines.
+    <<memmove>> requires no supporting OS subroutines.
 
-QUICKREF
-    memmove ansi pure
+    QUICKREF
+        memmove ansi pure
 */
 
-#include <string.h>
 #include <_ansi.h>
-#include <stddef.h>
 #include <limits.h>
+#include <stddef.h>
+#include <string.h>
 
 /* Nonzero if either X or Y is not aligned on a "long" boundary.  */
-#define UNALIGNED(X, Y) \
-  (((long)X & (sizeof (long) - 1)) | ((long)Y & (sizeof (long) - 1)))
+#define UNALIGNED(X, Y) (((long)X & (sizeof(long) - 1)) | ((long)Y & (sizeof(long) - 1)))
 
 /* How many bytes are copied each iteration of the 4X unrolled loop.  */
-#define BIGBLOCKSIZE    (sizeof (long) << 2)
+#define BIGBLOCKSIZE (sizeof(long) << 2)
 
 /* How many bytes are copied each iteration of the word copy loop.  */
-#define LITTLEBLOCKSIZE (sizeof (long))
+#define LITTLEBLOCKSIZE (sizeof(long))
 
 /* Threshhold for punting to the byte copier.  */
-#define TOO_SMALL(LEN)  ((LEN) < BIGBLOCKSIZE)
+#define TOO_SMALL(LEN) ((LEN) < BIGBLOCKSIZE)
 
 /*SUPPRESS 20*/
-_PTR
-_DEFUN(memmove, (dst_void, src_void, length),
-       _PTR dst_void _AND _CONST _PTR src_void _AND size_t length) {
+_PTR _DEFUN(memmove, (dst_void, src_void, length),
+            _PTR dst_void _AND _CONST _PTR src_void _AND size_t length) {
 #if defined(PREFER_SIZE_OVER_SPEED) || defined(__OPTIMIZE_SIZE__)
     char *dst = dst_void;
     _CONST char *src = src_void;
@@ -68,7 +66,8 @@ _DEFUN(memmove, (dst_void, src_void, length),
         while(length--) {
             *--dst = *--src;
         }
-    } else {
+    }
+    else {
         while(length--) {
             *dst++ = *src++;
         }
@@ -89,13 +88,14 @@ _DEFUN(memmove, (dst_void, src_void, length),
         while(len--) {
             *--dst = *--src;
         }
-    } else {
-    /* Use optimizing algorithm for a non-destructive copy to closely 
-       match memcpy. If the size is small or either SRC or DST is unaligned,
-       then punt into the byte copy loop.  This should be rare.  */
+    }
+    else {
+        /* Use optimizing algorithm for a non-destructive copy to closely
+           match memcpy. If the size is small or either SRC or DST is unaligned,
+           then punt into the byte copy loop.  This should be rare.  */
         if(!TOO_SMALL(len) && !UNALIGNED(src, dst)) {
-            aligned_dst = (long *) dst;
-            aligned_src = (long *) src;
+            aligned_dst = (long *)dst;
+            aligned_src = (long *)src;
 
             /* Copy 4X long words at a time if possible.  */
             while(len >= BIGBLOCKSIZE) {
@@ -113,8 +113,8 @@ _DEFUN(memmove, (dst_void, src_void, length),
             }
 
             /* Pick up any residual with a byte copier.  */
-            dst = (char *) aligned_dst;
-            src = (char *) aligned_src;
+            dst = (char *)aligned_dst;
+            src = (char *)aligned_src;
         }
 
         while(len--) {
@@ -123,5 +123,5 @@ _DEFUN(memmove, (dst_void, src_void, length),
     }
 
     return dst_void;
-#endif  /* not PREFER_SIZE_OVER_SPEED */
+#endif /* not PREFER_SIZE_OVER_SPEED */
 }

--- a/target-src/dcload/scif.c
+++ b/target-src/dcload/scif.c
@@ -1,4 +1,4 @@
-/* 
+/*
  * This file is part of the dcload Dreamcast serial loader
  *
  * Copyright (C) 2001 Andrew Kieschnick <andrewk@napalm-x.com>
@@ -28,30 +28,34 @@ void scif_flush(void) {
     int v;
 
     *SCFSR2 &= 0xbf;
-    while(!((v = *SCFSR2) & 0x40));
+    while(!((v = *SCFSR2) & 0x40))
+        ;
     *SCFSR2 = v & 0xbf;
 }
 
 void scif_init(int bps) {
     /* Modified to allow external baudrate (bps == 0) */
     int i;
- 
-    *SCSCR2 = bps ? 0x0 : 0x02;	/* clear TE and RE bits / if (bps == 0) CKE1 on (bit 1) */
-    *SCFCR2 = 0x6;		/* set TFRST and RFRST bits in SCFCR2 */
-    *SCSMR2 = 0x0;		/* set data transfer format 8n1 */
-   
-    if(bps) *SCBRR2 = (50 * 1000000) / (32 * bps) - 1;	/* if (bps != 0) set baudrate */
- 
-    for(i = 0; i < 100000; i++);	/* delay at least 1 bit interval */
- 
+
+    *SCSCR2 = bps ? 0x0 : 0x02; /* clear TE and RE bits / if (bps == 0) CKE1 on (bit 1) */
+    *SCFCR2 = 0x6;              /* set TFRST and RFRST bits in SCFCR2 */
+    *SCSMR2 = 0x0;              /* set data transfer format 8n1 */
+
+    if(bps)
+        *SCBRR2 = (50 * 1000000) / (32 * bps) - 1; /* if (bps != 0) set baudrate */
+
+    for(i = 0; i < 100000; i++)
+        ; /* delay at least 1 bit interval */
+
     *SCFCR2 = 12;
-    *SCFCR2 = 0x8;		/* set MCE in SCFCR2 */
+    *SCFCR2 = 0x8; /* set MCE in SCFCR2 */
     *SCSPTR2 = 0;
     *SCFSR2 = 0x60;
     *SCLSR2 = 0;
-    *SCSCR2 = bps ? 0x30 : 0x32;	/* set TE and RE bits / if (bps == 0) CKE1 on (bit 1) */
- 
-    for(i = 0; i < 100000; i++); 
+    *SCSCR2 = bps ? 0x30 : 0x32; /* set TE and RE bits / if (bps == 0) CKE1 on (bit 1) */
+
+    for(i = 0; i < 100000; i++)
+        ;
 }
 
 unsigned char scif_getchar(void) {
@@ -61,25 +65,25 @@ unsigned char scif_getchar(void) {
     *VIDBORDER = ~(*VIDBORDER & 0x00ffffff);
 #endif
 
-    while (!(*SCFSR2 & 0x2));	/* check RDF */
-    foo = *SCFRDR2;		/* read data */
-    *SCFSR2 &= 0xfffd;		/* clear RDF */
+    while(!(*SCFSR2 & 0x2))
+        ;              /* check RDF */
+    foo = *SCFRDR2;    /* read data */
+    *SCFSR2 &= 0xfffd; /* clear RDF */
 
     return foo;
 }
 
-unsigned int scif_isdata(void) {
-    return (*SCFSR2 & 0x2);
-}
+unsigned int scif_isdata(void) { return (*SCFSR2 & 0x2); }
 
 void scif_putchar(unsigned char foo) {
 #ifdef BORDER_FLASH
     *VIDBORDER = ~(*VIDBORDER & 0x00ffffff);
 #endif
 
-    while(!(*SCFSR2 & 0x20));	/* check TDFE */
-    *SCFTDR2 = foo;		/* send data */
-    *SCFSR2 &= 0xff9f;		/* clear TDFE and TEND */
+    while(!(*SCFSR2 & 0x20))
+        ;              /* check TDFE */
+    *SCFTDR2 = foo;    /* send data */
+    *SCFSR2 &= 0xff9f; /* clear TDFE and TEND */
 }
 
 void scif_puts(unsigned char *foo) {
@@ -87,7 +91,7 @@ void scif_puts(unsigned char *foo) {
 
     while(foo[i] != 0) {
         scif_putchar(foo[i]);
-        if (foo[i] == '\n')
+        if(foo[i] == '\n')
             scif_putchar('\r');
         i++;
     }

--- a/target-src/dcload/scif.h
+++ b/target-src/dcload/scif.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * This file is part of the dcload Dreamcast serial loader
  *
  * Copyright (C) 2001 Andrew Kieschnick <andrewk@napalm-x.com>
@@ -23,34 +23,34 @@
 #define __SCIF_H__
 
 /* serial mode register */
-#define SCSMR2  (volatile unsigned short *) 0xffe80000
+#define SCSMR2  (volatile unsigned short *)0xffe80000
 
 /* bit rate register */
-#define SCBRR2  (volatile unsigned char *)  0xffe80004
+#define SCBRR2  (volatile unsigned char *)0xffe80004
 
 /* serial control register */
-#define SCSCR2  (volatile unsigned short *) 0xffe80008
+#define SCSCR2  (volatile unsigned short *)0xffe80008
 
 /* transmit fifo data register */
-#define SCFTDR2 (volatile unsigned char *)  0xffe8000c
+#define SCFTDR2 (volatile unsigned char *)0xffe8000c
 
 /* serial status register */
-#define SCFSR2  (volatile unsigned short *) 0xffe80010
+#define SCFSR2  (volatile unsigned short *)0xffe80010
 
 /* receive fifo data register */
-#define SCFRDR2 (volatile unsigned char *)  0xffe80014
+#define SCFRDR2 (volatile unsigned char *)0xffe80014
 
 /* fifo control register */
-#define SCFCR2  (volatile unsigned short *) 0xffe80018
+#define SCFCR2  (volatile unsigned short *)0xffe80018
 
 /* fifo data count register */
-#define SCFDR2  (volatile unsigned short *) 0xffe8001c
+#define SCFDR2  (volatile unsigned short *)0xffe8001c
 
 /* serial port register */
-#define SCSPTR2 (volatile unsigned short *) 0xffe80020
+#define SCSPTR2 (volatile unsigned short *)0xffe80020
 
 /* line status register */
-#define SCLSR2  (volatile unsigned short *) 0xffe80024
+#define SCLSR2  (volatile unsigned short *)0xffe80024
 
 void scif_flush(void);
 void scif_init(int bps);

--- a/target-src/dcload/syscalls.c
+++ b/target-src/dcload/syscalls.c
@@ -20,6 +20,7 @@
  */
 
 #include <unistd.h>
+#include <unistd.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
@@ -28,10 +29,8 @@
 #include <dirent.h>
 #include "scif.h"
 
-extern void load_data_block_general(unsigned char *addr,
-                           unsigned int size, unsigned int verbose);
-extern unsigned int send_data_block_compressed(unsigned char * addr,
-                           unsigned int size);
+extern void load_data_block_general(unsigned char *addr, unsigned int size, unsigned int verbose);
+extern unsigned int send_data_block_compressed(unsigned char *addr, unsigned int size);
 extern unsigned int get_uint(void);
 
 extern int put_uint(unsigned int val);
@@ -62,7 +61,7 @@ int write(int fd, const void *buf, size_t count) {
     scif_putchar(2);
     put_uint(fd);
     put_uint(count);
-    send_data_block_compressed((unsigned char*)buf, count);
+    send_data_block_compressed((unsigned char *)buf, count);
 
     return (get_uint());
 }
@@ -74,7 +73,7 @@ int open(const char *pathname, int flags, ...) {
     va_start(ap, flags);
     scif_putchar(4);
     put_uint(namelen);
-    send_data_block_compressed((unsigned char*)pathname, namelen);
+    send_data_block_compressed((unsigned char *)pathname, namelen);
     put_uint(flags);
     put_uint(va_arg(ap, int));
     va_end(ap);
@@ -94,7 +93,7 @@ int creat(const char *pathname, mode_t mode) {
 
     scif_putchar(6);
     put_uint(namelen);
-    send_data_block_compressed((unsigned char*)pathname, namelen);
+    send_data_block_compressed((unsigned char *)pathname, namelen);
     put_uint(mode);
 
     return (get_uint());
@@ -106,9 +105,9 @@ int link(const char *oldpath, const char *newpath) {
 
     scif_putchar(7);
     put_uint(namelen1);
-    send_data_block_compressed((unsigned char*)oldpath, namelen1);
+    send_data_block_compressed((unsigned char *)oldpath, namelen1);
     put_uint(namelen2);
-    send_data_block_compressed((unsigned char*)newpath, namelen2);
+    send_data_block_compressed((unsigned char *)newpath, namelen2);
 
     return (get_uint());
 }
@@ -118,7 +117,7 @@ int unlink(const char *pathname) {
 
     scif_putchar(8);
     put_uint(namelen);
-    send_data_block_compressed((unsigned char*)pathname, namelen);
+    send_data_block_compressed((unsigned char *)pathname, namelen);
 
     return (get_uint());
 }
@@ -128,7 +127,7 @@ int chdir(const char *path) {
 
     scif_putchar(9);
     put_uint(namelen);
-    send_data_block_compressed((unsigned char*)path, namelen);
+    send_data_block_compressed((unsigned char *)path, namelen);
 
     return (get_uint());
 }
@@ -138,7 +137,7 @@ int chmod(const char *path, mode_t mode) {
 
     scif_putchar(10);
     put_uint(namelen);
-    send_data_block_compressed((unsigned char*)path, namelen);
+    send_data_block_compressed((unsigned char *)path, namelen);
     put_uint(mode);
 
     return (get_uint());
@@ -174,7 +173,7 @@ int fstat(int filedes, struct stat *buf) {
     return (get_uint());
 }
 
-time_t time(time_t * t) {
+time_t time(time_t *t) {
     scif_putchar(12);
 
     if(t) {
@@ -190,7 +189,7 @@ int stat(const char *file_name, struct stat *buf) {
 
     scif_putchar(13);
     put_uint(namelen);
-    send_data_block_compressed((unsigned char*)file_name, namelen);
+    send_data_block_compressed((unsigned char *)file_name, namelen);
 
     buf->st_dev = get_uint();
     buf->st_ino = get_uint();
@@ -214,7 +213,7 @@ int utime(const char *filename, struct utimbuf *buf) {
 
     scif_putchar(14);
     put_uint(namelen);
-    send_data_block_compressed((unsigned char*)filename, namelen);
+    send_data_block_compressed((unsigned char *)filename, namelen);
     if(buf) {
         put_uint(1);
         put_uint(buf->actime);
@@ -226,21 +225,21 @@ int utime(const char *filename, struct utimbuf *buf) {
     return (get_uint());
 }
 
-DIR * opendir(const char *name) {
+DIR *opendir(const char *name) {
     int namelen = strlen(name) + 1;
 
     scif_putchar(16);
     put_uint(namelen);
-    send_data_block_compressed((unsigned char*)name, namelen);
-    
-    return((DIR *)get_uint());
+    send_data_block_compressed((unsigned char *)name, namelen);
+
+    return ((DIR *)get_uint());
 }
 
 int closedir(DIR *dir) {
     scif_putchar(17);
     put_uint((unsigned int)dir);
 
-    return(get_uint());
+    return (get_uint());
 }
 
 struct dirent *readdir(DIR *dir) {
@@ -260,12 +259,12 @@ struct dirent *readdir(DIR *dir) {
         load_data_block_general(ourdirent.d_name, namelen, 0);
 
         return &ourdirent;
-    } else
-
-    return 0;
+    }
+    else
+        return 0;
 }
 
-size_t gdbpacket(const char *in_buf, unsigned int size_pack, char* out_buf) {
+size_t gdbpacket(const char *in_buf, unsigned int size_pack, char *out_buf) {
     size_t in_size = size_pack >> 16, out_size = size_pack & 0xffff, ret_size;
 
     scif_putchar(20);
@@ -274,7 +273,7 @@ size_t gdbpacket(const char *in_buf, unsigned int size_pack, char* out_buf) {
     put_uint((unsigned int)out_size);
 
     if(in_size)
-        send_data_block_compressed((unsigned char*)in_buf, in_size);
+        send_data_block_compressed((unsigned char *)in_buf, in_size);
 
     ret_size = get_uint();
 
@@ -288,5 +287,5 @@ int rewinddir(DIR *dir) {
     scif_putchar(21);
     put_uint((unsigned int)dir);
 
-    return(get_uint());
+    return (get_uint());
 }


### PR DESCRIPTION
Backports the changes listed [here](https://github.com/KallistiOSUnchained/dcload-serial/releases/tag/v1.0.6-final) plus later ones as of 2024/12/08 18:00 JST.

Since only functional changes were made to the host side, only the README.md version reflects it with the title 1.0.6-hostfix1. The Makefile.cfg still states 1.0.6.

Summary:
- Fix /pc browsing(opendir, closedir, readdir) and added rewinddir
- Code sanitization and correctness
- Fix custom baud rate support for modern macOS, confirmed working at 1.5MBaud on my M3 MacBook Pro, before fix it could not go higher than 115200.

