### PR TITLE
Import 64-bit fixes and rewinddir from dcload-ip

### DIFF
--- a/example-src/dcload-syscall.h
+++ b/example-src/dcload-syscall.h
@@ -1,7 +1,12 @@
 #ifndef __DCLOAD_SYSCALL_H__
 #define __DCLOAD_SYSCALL_H__
 
+#include <stdnoreturn.h>
+
 int dcloadsyscall(unsigned int syscall, ...);
+
+/* From crt0.S */
+noreturn void __exit(int status);
 
 #define pcreadnr 0
 #define pcwritenr 1

--- a/example-src/dcload-syscalls.c
+++ b/example-src/dcload-syscalls.c
@@ -63,7 +63,7 @@ int unlink(const char *path) {
         return -1;
 }
 
-void exit(int status) {
+noreturn void exit(int status) {
     if(*DCLOADMAGICADDR == DCLOADMAGICVALUE)
         dcloadsyscall(pcexitnr);
 


### PR DESCRIPTION
More details in the commit notes. This should fix directory reading in dc-load serial on 64-bit hosts (pretty much everything). The biggest additional changes were that I set the max opened dirs to be 512 (since it's the host side we don't need to be so stingy with memory) and I had to make one commit prior to the main update in order to be able to compile on gcc14 and up.