### PR TITLE
Fixed compilation error with gcc-14.2

### DIFF
--- a/example-src/dcload-syscalls.c
+++ b/example-src/dcload-syscalls.c
@@ -1,5 +1,7 @@
 #include "dcload-syscall.h"
 
+void __exit(int status);
+
 int link(const char *oldpath, const char *newpath) {
     if(*DCLOADMAGICADDR == DCLOADMAGICVALUE)
         return dcloadsyscall(pclinknr, oldpath, newpath);


### PR DESCRIPTION
There is a compilation error 'error: implicit declaration of function ‘__exit’; did you mean ‘_Exit’? [-Wimplicit-function-declaration]' when it's built under macOS and gcc 14.2. This simple fix solve issue