### PR TITLE
Fix windows when elf_begin opens FD without binary mode set

### DIFF
--- a/host-src/tool/dc-tool.c
+++ b/host-src/tool/dc-tool.c
@@ -947,7 +947,7 @@ unsigned int upload(unsigned char *filename, unsigned int address) {
         exit(-1);
     }
 
-    if((inputfd = open((char *)filename, O_RDONLY)) < 0) {
+    if((inputfd = open((char *)filename, O_RDONLY | O_BINARY)) < 0) {
         perror((char *)filename);
         exit(-1);
     }


### PR DESCRIPTION
The core issue: libelf 0.8.13 is very old (2006) and has a known bug on Windows where elf_begin() fails with "I/O error: raw read" because it uses read() internally but the file descriptor is opened in text mode on Windows, not binary mode. Windows translates \r\n in text mode which corrupts binary reads.