### PR TITLE
fix(host-src): fix header for musl libc

### DIFF
--- a/host-src/tool/dc-tool.c
+++ b/host-src/tool/dc-tool.c
@@ -38,6 +38,10 @@
 #include <windows.h>
 #else
 #ifdef __linux__
+#ifndef __GLIBC__
+/* musl libc */
+#include <asm/ioctls.h>
+#endif
 #include <asm/termbits.h>
 #include <sys/ioctl.h>
 #else


### PR DESCRIPTION
On alpine with musl libc, the asm/ioctls.h header must be installed via linux-header package and the asm/ioctls.h header must be added to resolve TCGETS2 and TCSETS2 macros.

note: at least, that's what I think